### PR TITLE
ci: migrate ecmwf-actions references to ecmwf

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   pypi:
-    uses: ecmwf-actions/reusable-workflows/.github/workflows/cd-pypi.yml@v2
+    uses: ecmwf/reusable-workflows/.github/workflows/cd-pypi.yml@v2
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
   downstream-ci:
     name: downstream-ci
     if: ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
-    uses: ecmwf-actions/downstream-ci/.github/workflows/downstream-ci.yml@main
+    uses: ecmwf/downstream-ci/.github/workflows/downstream-ci.yml@main
     with:
       troika: ecmwf/troika@${{ github.event.pull_request.head.sha || github.sha }}
       codecov_upload: true
@@ -35,7 +35,7 @@ jobs:
   downstream-ci-hpc:
     name: downstream-ci-hpc
     if: ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
-    uses: ecmwf-actions/downstream-ci/.github/workflows/downstream-ci-hpc.yml@main
+    uses: ecmwf/downstream-ci/.github/workflows/downstream-ci-hpc.yml@main
     with:
       troika: ecmwf/troika@${{ github.event.pull_request.head.sha || github.sha }}
     secrets: inherit

--- a/.github/workflows/label-public-pr.yml
+++ b/.github/workflows/label-public-pr.yml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   label:
-    uses: ecmwf-actions/reusable-workflows/.github/workflows/label-pr.yml@v2
+    uses: ecmwf/reusable-workflows/.github/workflows/label-pr.yml@v2

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -19,7 +19,7 @@ jobs:
   #   It will correctly handle addition of any new and removal of existing Git objects.
   sync:
     name: sync
-    uses: ecmwf-actions/reusable-workflows/.github/workflows/sync.yml@v2
+    uses: ecmwf/reusable-workflows/.github/workflows/sync.yml@v2
     secrets:
       target_repository: ecsdk/troika
       target_username: ClonedDuck


### PR DESCRIPTION
## Summary
The `ecmwf-actions` GitHub organization has been merged into `ecmwf`.
This PR updates workflow `uses:` directives from `ecmwf-actions/` to `ecmwf/`.

No functional changes - the actions are identical, just relocated.

---
*This PR was created automatically.*
